### PR TITLE
Feature/disable retry

### DIFF
--- a/Sources/BatchAuthorizeHelper.swift
+++ b/Sources/BatchAuthorizeHelper.swift
@@ -113,11 +113,14 @@ class BatchAuthorizeHelper {
         
         let task = connection?.URLSession.dataTask(with: request, completionHandler: { [weak self] data, response, sessionError in
             if let error = sessionError {
+                self?.connection?.retryPresenceChannelsForBatchLimitError()
+
                 self?.raiseBatchAuthError(forChannels: channels, response: nil, data: nil, error: error as NSError?)
                 return
             }
             
             guard let data = data else {
+                self?.connection?.retryPresenceChannelsForBatchLimitError()
                 self?.raiseBatchAuthError(forChannels: channels, response: response, data: nil, error: nil)
                 return
             }
@@ -125,7 +128,7 @@ class BatchAuthorizeHelper {
             
             guard (statusCode == 200 || statusCode == 201) else {
 
-//                self?.connection?.retryPresenceChannelsForBatchLimitError()
+                self?.connection?.retryPresenceChannelsForBatchLimitError()
 
                 let dataString = String(data: data, encoding: String.Encoding.utf8)
                 self?.raiseBatchAuthError(forChannels: channels, response: response, data: dataString, error: nil)

--- a/Sources/BatchAuthorizeHelper.swift
+++ b/Sources/BatchAuthorizeHelper.swift
@@ -109,7 +109,7 @@ class BatchAuthorizeHelper {
     }
     
     fileprivate func sendBatchAuthorisationRequest(request: URLRequest, channels: [PusherChannel]) {
-        print("[SEND BATCH REQUEST] \(request.url)")
+        print("[SEND BATCH REQUEST] \(String(describing: request.url))")
         
         let task = connection?.URLSession.dataTask(with: request, completionHandler: { [weak self] data, response, sessionError in
             if let error = sessionError {
@@ -136,6 +136,7 @@ class BatchAuthorizeHelper {
             }
             
             guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []), let json = jsonObject as? [String: AnyObject] else {
+                self?.connection?.retryPresenceChannelsForBatchLimitError()
                 self?.raiseBatchAuthError(forChannels: channels, response: response, data: nil, error: nil)
                 return
             }

--- a/Sources/BatchAuthorizeHelper.swift
+++ b/Sources/BatchAuthorizeHelper.swift
@@ -109,6 +109,8 @@ class BatchAuthorizeHelper {
     }
     
     fileprivate func sendBatchAuthorisationRequest(request: URLRequest, channels: [PusherChannel]) {
+        print("[SEND BATCH REQUEST] \(request.url)")
+        
         let task = connection?.URLSession.dataTask(with: request, completionHandler: { [weak self] data, response, sessionError in
             if let error = sessionError {
                 self?.raiseBatchAuthError(forChannels: channels, response: nil, data: nil, error: error as NSError?)
@@ -123,7 +125,7 @@ class BatchAuthorizeHelper {
             
             guard (statusCode == 200 || statusCode == 201) else {
 
-                self?.connection?.retryPresenceChannelsForBatchLimitError()
+//                self?.connection?.retryPresenceChannelsForBatchLimitError()
 
                 let dataString = String(data: data, encoding: String.Encoding.utf8)
                 self?.raiseBatchAuthError(forChannels: channels, response: response, data: dataString, error: nil)

--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -922,7 +922,7 @@ import CryptoSwift
     }
     
     func retryPresenceChannelsForBatchLimitError() {
-        throttleSubscriber.retryAndCutoffChannelWithout(prefix: "presence-")
+        throttleSubscriber.retryAndCutoffChannelWith(prefix: "presence-")
     }
 }
 

--- a/Sources/ThrottleSubscriber.swift
+++ b/Sources/ThrottleSubscriber.swift
@@ -128,7 +128,7 @@ class ThrottleSubscriber {
         }
     }
 
-    func retryAndCutoffChannelWithout(prefix: String) {
+    func retryAndCutoffChannelWith(prefix: String) {
         queue.async(flags: .barrier) { [weak self] in
             guard let self = self else { return }
             let criticalChannels = self.candidateChannels.filter({ $0.name.hasPrefix(prefix) })
@@ -175,7 +175,6 @@ class ThrottleSubscriber {
         if !connection.authorize(channels) {
             print("[ThrottleSubscriber] Unable to subscribe to channels")
         }
-        removeCandidate(channels)
     }
     
     private func authorizePriorityChannel(_ channel: PusherChannel) {

--- a/Sources/ThrottleSubscriber.swift
+++ b/Sources/ThrottleSubscriber.swift
@@ -195,7 +195,7 @@ class ExponentialBackoff {
     private(set) var isSchedule: Bool = false
 
     static func build() -> ExponentialBackoff {
-        return ExponentialBackoff(initialInterval: 0, maxIntervalTime: 30, multiplier: 2)
+        return ExponentialBackoff(initialInterval: 1, maxIntervalTime: 60, multiplier: 2)
     }
     
     init(initialInterval: TimeInterval, maxIntervalTime: TimeInterval, multiplier: Double) {

--- a/Sources/ThrottleSubscriber.swift
+++ b/Sources/ThrottleSubscriber.swift
@@ -50,7 +50,7 @@ fileprivate class Throttler {
 }
 
 class ThrottleSubscriber {
-    private var throttler = Throttler(minimumDelay: 1)
+    private var throttler = Throttler(minimumDelay: 5)
     weak var connection: PusherConnection? = nil
     private var candidateChannels = Set<PusherChannel>()
     private let queue = DispatchQueue(label: "ThrottleSubscriber.Queue", attributes: .concurrent)
@@ -115,7 +115,7 @@ class ThrottleSubscriber {
     func subscribedToChannel(name: String) {
         let channels = fetchCandidateChannels()
         let filterChannels = channels.filter({ $0.name == name })
-        if let channel = filterChannels.first {
+        if let channel = filterChannels.last {
             removeCandidate(channel)
         }
         exponentialBackoff.reset()

--- a/Sources/ThrottleSubscriber.swift
+++ b/Sources/ThrottleSubscriber.swift
@@ -145,6 +145,7 @@ class ThrottleSubscriber {
         var channels = [PusherChannel]()
         queue.sync {
             channels = Array(candidateChannels)
+            candidateChannels.removeAll()
         }
         return channels
     }

--- a/Sources/ThrottleSubscriber.swift
+++ b/Sources/ThrottleSubscriber.swift
@@ -102,9 +102,9 @@ class ThrottleSubscriber {
         }
     }
     
-    private func removeCandidate(_ channel: PusherChannel) {
+    private func removeCandidate(_ channels: [PusherChannel]) {
         queue.async(flags: .barrier) { [weak self] in
-            self?.candidateChannels.remove(channel)
+            self?.candidateChannels.subtract(channels)
         }
     }
     
@@ -116,7 +116,7 @@ class ThrottleSubscriber {
         let channels = fetchCandidateChannels()
         let filterChannels = channels.filter({ $0.name == name })
         if let channel = filterChannels.last {
-            removeCandidate(channel)
+            removeCandidate([channel])
         }
         exponentialBackoff.reset()
     }
@@ -145,7 +145,6 @@ class ThrottleSubscriber {
         var channels = [PusherChannel]()
         queue.sync {
             channels = Array(candidateChannels)
-            candidateChannels.removeAll()
         }
         return channels
     }
@@ -176,6 +175,7 @@ class ThrottleSubscriber {
         if !connection.authorize(channels) {
             print("[ThrottleSubscriber] Unable to subscribe to channels")
         }
+        removeCandidate(channels)
     }
     
     private func authorizePriorityChannel(_ channel: PusherChannel) {


### PR DESCRIPTION
### Description of the pull request
- 調整 retry機制
- 調整exponential 參數，拉長一點，起始為 2^1 最長為60sec。
- 還是要保留authorized失敗的channel，等到真的subscribe成功才清掉throttle裡面的channel

### Note
有跑過local authorized 回429，有符合預期的時間retry。