### PR TITLE
trigger retry if there is no channels data for particular channel

### DIFF
--- a/Sources/BatchAuthorizeHelper.swift
+++ b/Sources/BatchAuthorizeHelper.swift
@@ -152,7 +152,10 @@ class BatchAuthorizeHelper {
             }
         }
         
-        raiseBatchAuthError(forChannels: failureChannels, response: nil, data: nil, error: nil)
+        if failureChannels.count > 0 {
+            raiseBatchAuthError(forChannels: failureChannels, response: nil, data: nil, error: nil)
+            connection?.retryPresenceChannelsForBatchLimitError()
+        }
     }
 
     


### PR DESCRIPTION
### Description of the pull request
當authorization失敗但response 200的情況會沒處發exponential retry
...

#### Why is the change necessary?
觸發exponential retry
...
